### PR TITLE
New “es” and “es_x_tu” translations & fixes

### DIFF
--- a/language/es/info_acp_recenttopics.php
+++ b/language/es/info_acp_recenttopics.php
@@ -21,18 +21,33 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge(
 	$lang, array(
-	//PCA forum
+	// PCA foro
 	'RECENT_TOPICS_LIST'            => 'Mostrar en “Temas Recientes”',
 	'RECENT_TOPICS_LIST_EXPLAIN'    => 'Activar para mostrar los temas de este foro en “Temas Recientes”',
 
 	//PCA título
 	'RECENT_TOPICS'                 => 'Temas Recientes',
 	'RT_CONFIG'                     => 'Configuración',
-	'RECENT_TOPICS_EXPLAIN'         => 'En esta página puede cambiar las opciones especificas para la extensión “Temas Recientes”.<br /><br />Foros específicos pueden ser incluídos o excluídos editando los respectivos foros en el PCA.<br />Asegúrese también de comprobar los permisos de sus usuarios, los cuales permiten a los usuarios cambiar individualmente algunas de las opciones encontradas debajo.',
+	'RECENT_TOPICS_EXPLAIN'         => 'En esta página puede cambiar las opciones especificas para la extensión “Temas Recientes”.<br /><br />Foros específicos pueden ser incluídos o excluídos editando los respectivos foros en el PCA.<br />Asegúrese también de comprobar los permisos de sus usuarios, los cuales permiten a los usuarios cambiar individualmente algunas de las opciones encontradas abajo.',
 
-	//configuración general para los usuarios anónimos
-	'RT_OVERRIDABLE'                => 'Opciones sobreescribibles del PCU',
+	//ajustes globales
+	'RT_GLOBAL_SETTINGS'            => 'Opciones globales',
 	'RT_DISPLAY_INDEX'              => 'Mostrar en el índice',
+	'RT_NUMBER'                     => 'Temas Recientes',
+	'RT_NUMBER_EXP'                 => 'Número de temas a mostrar.',
+	'RT_PAGE_NUMBER'                => 'Páginas de temas recientes',
+	'RT_PAGE_NUMBER_EXP'            => 'Activar esta opción desactivará la paginación de la lista de temas recientes',
+	'RT_PAGE_NUMBERMAX'		=> 'Número máximo de páginas',
+	'RT_PAGE_NUMBERMAX_EXP'		=> 'Definir el número máximo de páginas (1-999)',
+	'RT_MIN_TOPIC_LEVEL'            => 'Nivel de tema mínimo',
+	'RT_MIN_TOPIC_LEVEL_EXP'        => 'Determina el nivel de tema mínimo para poder se mostrado. Solo mostrará temas del nivel especificado y superior.',
+	'RT_ANTI_TOPICS'                => 'Temas excluidos',
+	'RT_ANTI_TOPICS_EXP'            => 'Las IDs de los temas a excluír, separados por "," (Por ejemplo: 7,9)<br />Si no quiere excluir un tema, simplemente introduzca 0.',
+	'RT_PARENTS'                    => 'Mostrar foros padre',
+	'RT_PARENTS_EXP'                => 'Mostrar foros padre dentro de la fila del tema de “Temas Recientes”.',
+
+	// Opciones modificables por el usuario. Afectan a los usuarios anónimos y pueden ser sobreescritas por el PCU
+	'RT_OVERRIDABLE'                => 'Opciones sobreescribibles del PCU',
 	'RT_LOCATION'                   => 'Posición',
 	'RT_LOCATION_EXP'               => 'Elija un lugar para mostrar la lista de temas recientes.',
 	'RT_TOP'                        => 'Mostrar en la parte superior',
@@ -42,27 +57,26 @@ $lang = array_merge(
 	'RT_SORT_START_TIME_EXP'        => 'Habilitar para ordenar la lista de temas recientes en base a la hora de inicio del tema, en lugar de la de la última respesta.',
 	'RT_UNREAD_ONLY'                => 'Mostrar solo temas no leídos',
 	'RT_UNREAD_ONLY_EXP'            => 'Activar para mostrar solo temas no leídos (tanto si son “recientes” o no). Esta función utiliza la misma configuración (excluyendo foros, temas, etc.) que el modo normal. Nota: esto sólo funciona para usuarios identificados; los invitados verán la lista normal.',
-
-	//ajustes globales
-	'RT_GLOBAL_SETTINGS'            => 'Opciones globales',
-	'RT_NUMBER'                     => 'Temas Recientes',
-	'RT_NUMBER_EXP'                 => 'Número de temas a mostrar.',
-	'RT_PAGE_NUMBER'                => 'Páginas de temas recientes',
-	'RT_PAGE_NUMBER_EXP'            => 'Activar esta opción desactivará la paginación de la lista de temas recientes',
-	'RT_MIN_TOPIC_LEVEL'            => 'Nivel de tema mínimo',
-	'RT_MIN_TOPIC_LEVEL_EXP'        => 'Determina el nivel de tema mínimo para poder se mostrado. Solo mostrará temas del nivel especificado y superior.',
-	'RT_ANTI_TOPICS'                => 'Temas excluidos',
-	'RT_ANTI_TOPICS_EXP'            => 'Las IDs de los temas a excluír, separados por "," (Por ejemplo: 7,9)<br />Si no quiere excluir un tema, simplemente introduzca 0.',
-	'RT_PARENTS'                    => 'Mostrar foros padre',
-	'RT_PARENTS_EXP'                => 'Mostrar foros padre dentro de la fila del tema de “Temas Recientes”.',
 	'RT_RESET_DEFAULT'              => 'Reiniciar la configuración de los usuarios',
 	'RT_RESET_DEFAULT_EXP'          => 'Devuelve la configuración independiente de cada usuario de “Temas Recientes” al valor por defecto.',
-	'RT_PAGE_NUMBERMAX'		=> 'Número máximo de páginas',
-	'RT_PAGE_NUMBERMAX_EXP'		=> 'Definir el número máximo de páginas (1-999)',
-
-	//extensiones
+	
+	// extensiones
 	'RT_NICKVERGESSEN_NEWSPAGE'     => 'Soporte para la extensión “NewsPage”',
 	'RT_VIEW_ON'                    => 'Ver “Temas Recientes” en:',
 
+	//Version checker
+	'RT_VERSION_CHECK'				=> 'Comprobación de la versión',
+	'RT_LATEST_VERSION'				=> 'Última versión',
+	'RT_EXT_VERSION'				=> 'Versión de la extensión',
+	'RT_VERSION_ERROR'				=> '¡No se ha podido comprobar la última versión!',
+	'RT_CHECK_UPDATE'				=> 'Visita <a href="http://www.avathar.be/bbdkp/index.php">avathar.be</a> para comprobar si hay actualizaciones disponibles.',
+
+	//Donation
+	'RT_DONATE_URL'             => 'http://www.avathar.be/bbdkp/app.php/page/donate',
+	'PAYPAL_IMAGE_URL'          => 'https://www.paypalobjects.com/webstatic/en_US/i/btn/png/silver-pill-paypal-26px.png',
+	'PAYPAL_ALT'                => 'Donar usando PayPal',
+	'RT_DONATE'					=> 'Donar a RecentTopics',
+	'RT_DONATE_SHORT'			=> 'Haga una donación a RecentTopics',
+	'RT_DONATE_EXPLAIN'			=> 'RecentTopics es 100% gratis. Es un proyecto que hago en mi tiempo libre donde invierto mi tiempo y dinero por gusto. Si disfruta utilizando RecentTopics, por favor considere hacer una donación. Sin ataduras.',
 	)
 );

--- a/language/es/recenttopics.php
+++ b/language/es/recenttopics.php
@@ -10,7 +10,6 @@
  * Based on the original NV Recent Topics by Joas Schilling (nickvergessen)
  */
 
-
 if (!defined('IN_PHPBB'))
 {
 	exit;
@@ -23,5 +22,6 @@ if (empty($lang) || !is_array($lang))
 $lang = array_merge(
 	$lang, array(
 	'RECENT_TOPICS'    => 'Temas Recientes',
+	'RT_NO_TOPICS'		=> 'No hay nuevos temas que mostrar.',
 	)
 );

--- a/language/es/recenttopics_ucp.php
+++ b/language/es/recenttopics_ucp.php
@@ -19,6 +19,22 @@ if (empty($lang) || !is_array($lang))
 	$lang = array();
 }
 
+// DEVELOPERS PLEASE NOTE
+//
+// All language files should use UTF-8 as their encoding and the files must not contain a BOM.
+//
+// Placeholders can now contain order information, e.g. instead of
+// 'Page %s of %s' you can (and should) write 'Page %1$s of %2$s', this allows
+// translators to re-order the output of data while ensuring it remains correct
+//
+// You do not need this where single placeholders are used, e.g. 'Message %d' is fine
+// equally where a string contains only two placeholders which are used to wrap text
+// in a url you again do not need to specify an order e.g., 'Click %sHERE%s' is fine
+//
+// Some characters you may want to copy&paste:
+// ’ « » “ ” …
+//
+
 $lang = array_merge(
 	$lang, array(
 	'RT_ENABLE'              => 'Mostrar la lista de temas recientes',

--- a/language/es_x_tu/info_acp_recenttopics.php
+++ b/language/es_x_tu/info_acp_recenttopics.php
@@ -21,45 +21,62 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge(
 	$lang, array(
-	//PCA forum
-	'RECENT_TOPICS_LIST'            => 'Ver en "temas recientes"',
-	'RECENT_TOPICS_LIST_EXPLAIN'    => 'Serán los temas de este foro los que se mostrarán en el índice de "temas recientes"?',
+	// PCA foro
+	'RECENT_TOPICS_LIST'            => 'Mostrar en “Temas Recientes”',
+	'RECENT_TOPICS_LIST_EXPLAIN'    => 'Activar para mostrar los temas de este foro en “Temas Recientes”',
 
 	//PCA título
 	'RECENT_TOPICS'                 => 'Temas Recientes',
-	'RECENT_TOPICS_EXPLAIN'         => 'Aquí puedes cambiar la configuración de temas recientes. <br /> <br /> Foro individual puede ser incluido o excluido cambiando su configuración en el PCA. <br /> Además, a través de la configuración de esta página, se puede permiten a los usuarios editar el propio cierta medida los aspectos',
-	'RT_CONFIG'                     => 'configuración',
-
-	//configuración general para los usuarios anónimos
-	'RT_OVERRIDABLE'                => 'Instituciones a las que los miembros del panel tiene prioridad',
-	'RT_DISPLAY_INDEX'              => 'Mostrar en la página de índice',
-	'RT_LOCATION'                   => 'Ubicación de la pantalla',
-	'RT_LOCATION_EXP'               => 'Elegir un lugar para mostrar los últimos temas.',
-	'RT_TOP'                        => 'Mostrar en la parte superior',
-	'RT_BOTTOM'                     => 'Mostrar en el fondo',
-	'RT_SIDE'                       => 'Mostrar en el lado derecho',
-	'RT_SORT_START_TIME'            => 'Ordenar temas por la hora de inicio',
-	'RT_SORT_START_TIME_EXP'        => 'Habilitar para ordenar los temas recientes sobre la hora de inicio del tema, en lugar de la última que se respondió.',
-	'RT_UNREAD_ONLY'                => 'Mostrar sólo temas no leídos',
-	'RT_UNREAD_ONLY_EXP'            => 'Esta opción sólo mostrará temas no leídos (tanto si son "recientes" o no). Esta función utiliza la misma configuración (excluyendo forums/topics etc.) que el modo normal. Nota: esto sólo funciona para usuarios registrados e identificados; los invitados podrán obtener la lista normal.',
+	'RT_CONFIG'                     => 'Configuración',
+	'RECENT_TOPICS_EXPLAIN'         => 'En esta página puede cambiar las opciones especificas para la extensión “Temas Recientes”.<br /><br />Foros específicos pueden ser incluídos o excluídos editando los respectivos foros en el PCA.<br />Asegúrate también de comprobar los permisos de tus usuarios, los cuales permiten a los usuarios cambiar individualmente algunas de las opciones encontradas abajo.',
 
 	//ajustes globales
-	'RT_GLOBAL_SETTINGS'            => 'Ajustes globales',
-	'RT_NUMBER'                     => 'Temas recientes',
-	'RT_NUMBER_EXP'                 => 'Número de temas mostrados en el índice.',
+	'RT_GLOBAL_SETTINGS'            => 'Opciones globales',
+	'RT_DISPLAY_INDEX'              => 'Mostrar en el índice',
+	'RT_NUMBER'                     => 'Temas Recientes',
+	'RT_NUMBER_EXP'                 => 'Número de temas a mostrar.',
 	'RT_PAGE_NUMBER'                => 'Páginas de temas recientes',
-	'RT_PAGE_NUMBER_EXP'            => 'Puede mostrar más temas recientes usando una pequeña paginación. Solo tiene que introducir 1 para desactivar esta función. Si introduce 0, habrá tantas páginas como sean necesarias para mostrar todos los temas.',
-	'RT_MIN_TOPIC_LEVEL'            => 'Tipo de nivel mínimo del tema',
-	'RT_MIN_TOPIC_LEVEL_EXP'        => 'Determina el tipo de nivel mínimo del tema a mostrar. Se mostrará temas del nivel establecido, y superior.',
+	'RT_PAGE_NUMBER_EXP'            => 'Activar esta opción desactivará la paginación de la lista de temas recientes',
+	'RT_PAGE_NUMBERMAX'		=> 'Número máximo de páginas',
+	'RT_PAGE_NUMBERMAX_EXP'		=> 'Definir el número máximo de páginas (1-999)',
+	'RT_MIN_TOPIC_LEVEL'            => 'Nivel de tema mínimo',
+	'RT_MIN_TOPIC_LEVEL_EXP'        => 'Determina el nivel de tema mínimo para poder se mostrado. Solo mostrará temas del nivel especificado y superior.',
 	'RT_ANTI_TOPICS'                => 'Temas excluidos',
-	'RT_ANTI_TOPICS_EXP'            => 'Separados por "," (Por ejemplo: 7,9)<br />Si no quiere excluir un tema, simplemente introduzca 0.',
+	'RT_ANTI_TOPICS_EXP'            => 'Las IDs de los temas a excluír, separados por "," (Por ejemplo: 7,9)<br />Si no quieres excluir un tema, simplemente introduce 0.',
 	'RT_PARENTS'                    => 'Mostrar foros padre',
-	'RT_PARENTS_EXP'                => 'Mostrar foros padre dentro de la fila tema, de temas recientes.',
-	'RT_PAGE_NUMBERMAX'             => 'Maximum number of pages',
-	'RT_PAGE_NUMBERMAX_EXP'         => 'Set the page maximum (1-999) to display in the recent topics pagination where the option “Full displaying of recent topics pages” is disabled.',
+	'RT_PARENTS_EXP'                => 'Mostrar foros padre dentro de la fila del tema de “Temas Recientes”.',
 
-	//extensiones
-	'RT_VIEW_ON'                    => 'Ver temas recientes en:',
+	// Opciones modificables por el usuario. Afectan a los usuarios anónimos y pueden ser sobreescritas por el PCU
+	'RT_OVERRIDABLE'                => 'Opciones sobreescribibles del PCU',
+	'RT_LOCATION'                   => 'Posición',
+	'RT_LOCATION_EXP'               => 'Elije un lugar para mostrar la lista de temas recientes.',
+	'RT_TOP'                        => 'Mostrar en la parte superior',
+	'RT_BOTTOM'                     => 'Mostrar en la parte inferior',
+	'RT_SIDE'                       => 'Mostrar en el lado derecho',
+	'RT_SORT_START_TIME'            => 'Ordenar temas por la hora de inicio',
+	'RT_SORT_START_TIME_EXP'        => 'Habilitar para ordenar la lista de temas recientes en base a la hora de inicio del tema, en lugar de la de la última respesta.',
+	'RT_UNREAD_ONLY'                => 'Mostrar solo temas no leídos',
+	'RT_UNREAD_ONLY_EXP'            => 'Activar para mostrar solo temas no leídos (tanto si son “recientes” o no). Esta función utiliza la misma configuración (excluyendo foros, temas, etc.) que el modo normal. Nota: esto sólo funciona para usuarios identificados; los invitados verán la lista normal.',
+	'RT_RESET_DEFAULT'              => 'Reiniciar la configuración de los usuarios',
+	'RT_RESET_DEFAULT_EXP'          => 'Devuelve la configuración independiente de cada usuario de “Temas Recientes” al valor por defecto.',
+	
+	// extensiones
+	'RT_NICKVERGESSEN_NEWSPAGE'     => 'Soporte para la extensión “NewsPage”',
+	'RT_VIEW_ON'                    => 'Ver “Temas Recientes” en:',
 
+	//Version checker
+	'RT_VERSION_CHECK'				=> 'Comprobación de la versión',
+	'RT_LATEST_VERSION'				=> 'Última versión',
+	'RT_EXT_VERSION'				=> 'Versión de la extensión',
+	'RT_VERSION_ERROR'				=> '¡No se ha podido comprobar la última versión!',
+	'RT_CHECK_UPDATE'				=> 'Visita <a href="http://www.avathar.be/bbdkp/index.php">avathar.be</a> para comprobar si hay actualizaciones disponibles.',
+
+	//Donation
+	'RT_DONATE_URL'             => 'http://www.avathar.be/bbdkp/app.php/page/donate',
+	'PAYPAL_IMAGE_URL'          => 'https://www.paypalobjects.com/webstatic/en_US/i/btn/png/silver-pill-paypal-26px.png',
+	'PAYPAL_ALT'                => 'Donar usando PayPal',
+	'RT_DONATE'					=> 'Donar a RecentTopics',
+	'RT_DONATE_SHORT'			=> 'Haga una donación a RecentTopics',
+	'RT_DONATE_EXPLAIN'			=> 'RecentTopics es 100% gratis. Es un proyecto que hago en mi tiempo libre donde invierto mi tiempo y dinero por gusto. Si disfrutas utilizando RecentTopics, por favor considera hacer una donación. Sin ataduras.',
 	)
 );

--- a/language/es_x_tu/permissions_recenttopics.php
+++ b/language/es_x_tu/permissions_recenttopics.php
@@ -21,10 +21,10 @@ if (empty($lang) || !is_array($lang))
 
 $lang = array_merge(
 	$lang, array(
-	'ACL_U_RT_VIEW'            => 'Temas recientes: Puedes ocultar la lista de temas recientes',
-	'ACL_U_RT_ENABLE'          => 'Temas recientes: Puedes activar la lista de temas recientes',
-	'ACL_U_RT_LOCATION'        => 'Temas recientes: Selecciona la posición de visualización',
-	'ACL_U_RT_SORT_START_TIME' => 'Temas recientes: Puedes cambiar el método de clasificación de temas recientes',
-	'ACL_U_RT_UNREAD_ONLY'     => 'Temas recientes: Puedes ver la lista de los últimos temas temas no leídos',
+	'ACL_U_RT_VIEW'            => 'Temas recientes: Puedes ver la lista de temas recientes',
+	'ACL_U_RT_ENABLE'          => 'Temas recientes: Puedes activar o desactivar la lista de temas recientes',
+	'ACL_U_RT_LOCATION'        => 'Temas recientes: Puedes seleccionar la posición donde será mostrada',
+	'ACL_U_RT_SORT_START_TIME' => 'Temas recientes: Puedes cambiar el método de ordenación',
+	'ACL_U_RT_UNREAD_ONLY'     => 'Temas recientes: Puedes activar el módo “solo no leídos”',
 	)
 );

--- a/language/es_x_tu/recenttopics.php
+++ b/language/es_x_tu/recenttopics.php
@@ -10,7 +10,6 @@
  * Based on the original NV Recent Topics by Joas Schilling (nickvergessen)
  */
 
-
 if (!defined('IN_PHPBB'))
 {
 	exit;
@@ -23,5 +22,6 @@ if (empty($lang) || !is_array($lang))
 $lang = array_merge(
 	$lang, array(
 	'RECENT_TOPICS'    => 'Temas Recientes',
+	'RT_NO_TOPICS'		=> 'No hay nuevos temas que mostrar.',
 	)
 );

--- a/language/es_x_tu/recenttopics_ucp.php
+++ b/language/es_x_tu/recenttopics_ucp.php
@@ -19,16 +19,32 @@ if (empty($lang) || !is_array($lang))
 	$lang = array();
 }
 
+// DEVELOPERS PLEASE NOTE
+//
+// All language files should use UTF-8 as their encoding and the files must not contain a BOM.
+//
+// Placeholders can now contain order information, e.g. instead of
+// 'Page %s of %s' you can (and should) write 'Page %1$s of %2$s', this allows
+// translators to re-order the output of data while ensuring it remains correct
+//
+// You do not need this where single placeholders are used, e.g. 'Message %d' is fine
+// equally where a string contains only two placeholders which are used to wrap text
+// in a url you again do not need to specify an order e.g., 'Click %sHERE%s' is fine
+//
+// Some characters you may want to copy&paste:
+// ’ « » “ ” …
+//
+
 $lang = array_merge(
 	$lang, array(
-	'RT_ENABLE'              => 'Visualizar los temas recientes',
-	'RT_LOCATION'            => 'Ubicación de la pantalla',
-	'RT_LOCATION_EXP'        => 'Elegir un lugar para mostrar los últimos temas.',
-	'RT_SORT_START_TIME'     => 'Ordenar los últimos temas de tiempo inicial del tema',
-	'RT_SORT_START_TIME_EXP' => 'Los temas están ordenados de acuerdo con su respectiva fecha de apertura y no de acuerdo a la del último mensaje',
-	'RT_UNREAD_ONLY'         => 'Mostrar sólo los temas no leídos en los últimos temas',
+	'RT_ENABLE'              => 'Mostrar la lista de temas recientes',
+	'RT_LOCATION'            => 'Seleccionar posición',
+	'RT_LOCATION_EXP'        => 'Elige una posición para mostrar la lista de temas recientes',
+	'RT_SORT_START_TIME'     => 'Ordenar los temas recientes por la hora de inicio de los temas',
+	'RT_SORT_START_TIME_EXP' => 'Los temas están ordenados de acuerdo con su respectiva fecha de inicio y no de acuerdo a la del último mensaje',
+	'RT_UNREAD_ONLY'         => 'Mostrar solo los temas no leídos en la lista de temas recientes',
 	'RT_TOP'                 => 'Mostrar en la parte superior',
-	'RT_BOTTOM'              => 'Mostrar en el fondo',
+	'RT_BOTTOM'              => 'Mostrar en la parte inferior',
 	'RT_SIDE'                => 'Mostrar en el lado derecho',
 	)
 );


### PR DESCRIPTION
I've made some changes to both language packs.

First of, all new translations for version 2.2.2 were added to the `es` language pack. Also, to make it easier to maintain, all entries were reorganized to mimic the English translation files.

With regard to the `es_x_tu` language pack, I modified most of the translations to match the `es` translations, as the pack is just a hierarchical variant of it (most part of the translations should be the same). This change not only adds the new translations for 2.2.2, but also makes it more maintainable.