### PR TITLE
Fixed Recent Topics pager by providing a correct rows number value

### DIFF
--- a/core/recenttopics.php
+++ b/core/recenttopics.php
@@ -737,12 +737,27 @@ use phpbb\language\language;
 				$vars = array('sql_array');
 				extract($this->dispatcher->trigger_event('paybas.recenttopics.sql_pull_topics_list', compact($vars)));
 
+				// Generate and execute count query.
+				$count_sql_array = $sql_array;
+				$count_sql_array['SELECT'] = 'COUNT(t.topic_id) as topic_count';
+				unset($count_sql_array['ORDER_BY']);
+
+				$sql = $this->db->sql_build_query('SELECT', $count_sql_array);
+				$result = $this->db->sql_query($sql);
+
+				// Get quantity of matched topics.
+				$num_rows = $this->db->sql_fetchfield('topic_count', $result);
+
+				// Free query result.
+				$this->db->sql_freeresult($result);
+
+				// Load topics list.
 				$sql = $this->db->sql_build_query('SELECT', $sql_array);
 				$result = $this->db->sql_query_limit($sql, $total_topics_limit);
 
 				if ($result != null)
 				{
-					$rtstart = min((int) $result->num_rows - 1 , $rtstart);
+					$rtstart = min((int) $num_rows - 1 , $rtstart);
 				}
 				else
 				{


### PR DESCRIPTION
Currently $rtstart variable is always limited to **topics_per_page - 1** which is a static value, so that we always see only the first page even if **recent_topics_start** GET parameter is much bigger.
Also because of that there always is one missing topic.

I've added a count query to get a correct number of total topics result.