### PR TITLE
Add 2 phpBB core template events

### DIFF
--- a/styles/all/template/recent_topics_body_topbottom.html
+++ b/styles/all/template/recent_topics_body_topbottom.html
@@ -63,7 +63,7 @@
 
 						{% if not S_IS_BOT %}
 						<div class="responsive-show" style="display: none;">
-							{{ lang('LAST_POST') }} {{ lang('POST_BY_AUTHOR') }} {{ recent_topics.LAST_POST_AUTHOR_FULL }} &laquo; <a href="{{ recent_topics.U_LAST_POST }}" title="{{ lang('GOTO_LAST_POST') }}">{{ recent_topics.LAST_POST_TIME }}</a>
+							{{ lang('LAST_POST') }} {{ lang('POST_BY_AUTHOR') }} {% EVENT viewforum_body_last_post_author_username_prepend %} {{ recent_topics.LAST_POST_AUTHOR_FULL }} {% EVENT viewforum_body_last_post_author_username_append %} &laquo; <a href="{{ recent_topics.U_LAST_POST }}" title="{{ lang('GOTO_LAST_POST') }}">{{ recent_topics.LAST_POST_TIME }}</a>
 							{% if recent_topics.S_POST_GLOBAL and FORUM_ID != recent_topics.FORUM_ID %}<br />{{ lang('POSTED') }} {{ lang('IN') }} <a href="{{ recent_topics.U_VIEW_FORUM }}">{{ recent_topics.FORUM_NAME }}</a>{% endif %}
 						</div>
 						{% if recent_topics.REPLIES %}<span class="responsive-show left-box" style="display: none;">{{ lang('REPLIES') }}{{ lang('COLON') }} <strong>{{ recent_topics.REPLIES }}</strong></span>{% endif %}
@@ -89,7 +89,7 @@
 
 						<div class="responsive-hide">
 							{% if recent_topics.S_HAS_POLL %}<i class="icon fa-bar-chart fa-fw" aria-hidden="true"></i>{% endif %}
-							{{ lang('POST_BY_AUTHOR') }} {{ recent_topics.TOPIC_AUTHOR_FULL }} &raquo; {{ recent_topics.FIRST_POST_TIME }}
+							{{ lang('POST_BY_AUTHOR') }} {% EVENT viewforum_body_topic_author_username_prepend %} {{ recent_topics.TOPIC_AUTHOR_FULL }} {% EVENT viewforum_body_topic_author_username_append %} &raquo; {{ recent_topics.FIRST_POST_TIME }}
 							{% if recent_topics.S_POST_GLOBAL and FORUM_ID != recent_topics.FORUM_ID %} &raquo; {{ lang('IN') }} <a href="{{ recent_topics.U_VIEW_FORUM }}">{{ recent_topics.FORUM_NAME }}</a>
 							{% elseif recent_topics.U_VIEW_FORUM and recent_topics.FORUM_NAME %} &raquo; {{ lang('IN') }} {% for parent_forums in recent_topics.parent_forums %}<a href="{{ parent_forums.U_VIEW_FORUM }}">{{ parent_forums.FORUM_NAME }}</a> &raquo; {% endfor %}<a href="{{ recent_topics.U_VIEW_FORUM }}">{{ recent_topics.FORUM_NAME }}</a>{% endif %}
 						</div>
@@ -101,7 +101,7 @@
 					<dd class="views">{{ recent_topics.VIEWS }} <dfn>{{ lang('VIEWS') }}</dfn></dd>
 					<dd class="lastpost">
 
-						<span><dfn>{{ lang('LAST_POST') }} </dfn>{{ lang('POST_BY_AUTHOR') }} {{ recent_topics.LAST_POST_AUTHOR_FULL }}
+						<span><dfn>{{ lang('LAST_POST') }} </dfn>{{ lang('POST_BY_AUTHOR') }} {% EVENT viewforum_body_last_post_author_username_prepend %} {{ recent_topics.LAST_POST_AUTHOR_FULL }} {% EVENT viewforum_body_last_post_author_username_append %}
 						{% if not S_IS_BOT %}
 							<a href="{{ recent_topics.U_LAST_POST }}" title="{{ lang('GOTO_LAST_POST') }}">
 								<i class="icon fa-external-link-square fa-fw icon-lightgray icon-md" aria-hidden="true"></i>


### PR DESCRIPTION
- `viewforum_body_topic_author_username_append`
- `viewforum_body_topic_author_username_prepend`
- `viewforum_body_last_post_author_username_append`
- `viewforum_body_last_post_author_username_prepend`

To support "Member Avatar & Status [MAS]" and solve the issue :
https://github.com/dark-1/memberavatarstatus/issues/8
in commits :
1. https://github.com/dark-1/memberavatarstatus/commit/ece377cf99544581709fe5d08957b76fc0fc9d5a
2. https://github.com/dark-1/memberavatarstatus/commit/b917206b99098139c2936c13c6258f4dc6d3c086