### PR TITLE
Topic title should always point to the beginning of the topic.

### DIFF
--- a/styles/all/template/recent_topics_body_side.html
+++ b/styles/all/template/recent_topics_body_side.html
@@ -35,7 +35,7 @@
 					{% if recent_topics.S_UNREAD_TOPIC and not S_IS_BOT %}<a href="{{ recent_topics.U_NEWEST_POST }}" class="row-item-link"></a>{% endif %}
 					<div class="list-inner">
 						{% EVENT topiclist_row_prepend %}
-						<a href="{{ recent_topics.U_LAST_POST }}" class="topictitle">{{ recent_topics.LAST_POST_SUBJECT }}</a>
+						<a href="{{ recent_topics.U_VIEW_TOPIC }}" class="topictitle">{{ recent_topics.TOPIC_TITLE }}</a>
 						<div class="forum-links">
 							{% if recent_topics.S_HAS_POLL %}<i class="icon fa-bar-chart fa-fw" aria-hidden="true"></i>{% endif %}
 							{% if recent_topics.S_POST_GLOBAL and FORUM_ID != recent_topics.FORUM_ID %}

--- a/styles/all/template/recent_topics_body_topbottom.html
+++ b/styles/all/template/recent_topics_body_topbottom.html
@@ -46,7 +46,7 @@
 						{% if recent_topics.S_UNREAD_TOPIC and not S_IS_BOT %}
 						<a href="{{ recent_topics.U_NEWEST_POST }}">
 						<i class="icon fa-file fa-fw icon-red icon-md" aria-hidden="true"></i><span class="sr-only"></span>
-						</a> {% endif %}<a href="{{ recent_topics.U_LAST_POST }}" class="topictitle">{{ recent_topics.LAST_POST_SUBJECT }}</a>
+						</a> {% endif %}<a href="{{ recent_topics.U_VIEW_TOPIC }}" class="topictitle">{{ recent_topics.TOPIC_TITLE }}</a>
 
 						{% if recent_topics.ATTACH_ICON_IMG %}<i class="icon fa-paperclip fa-fw" aria-hidden="true"></i>{% endif %}
 

--- a/styles/all/template/recent_topics_page.html
+++ b/styles/all/template/recent_topics_page.html
@@ -46,7 +46,7 @@
                         {% if recent_topics.S_UNREAD_TOPIC and not S_IS_BOT %}
                         <a href="{{ recent_topics.U_NEWEST_POST }}">
                             <i class="icon fa-file fa-fw icon-red icon-md" aria-hidden="true"></i><span class="sr-only"></span>
-                        </a> {% endif %}<a href="{{ recent_topics.U_LAST_POST }}" class="topictitle">{{ recent_topics.LAST_POST_SUBJECT }}</a>
+                        </a> {% endif %}<a href="{{ recent_topics.U_VIEW_TOPIC }}" class="topictitle">{{ recent_topics.TOPIC_TITLE }}</a>
 
                         {% if recent_topics.ATTACH_ICON_IMG %}<i class="icon fa-paperclip fa-fw" aria-hidden="true"></i>{% endif %}
 

--- a/styles/pbwow3/template/recent_topics_body_topbottom.html
+++ b/styles/pbwow3/template/recent_topics_body_topbottom.html
@@ -40,7 +40,7 @@
 						{% if recent_topics.S_UNREAD_TOPIC and not S_IS_BOT %}
 						<a href="{{ recent_topics.U_NEWEST_POST }}">
 						<i class="icon fa-file fa-fw icon-red icon-md" aria-hidden="true"></i><span class="sr-only"></span>
-						</a> {% endif %}<a href="{{ recent_topics.U_LAST_POST }}" class="topictitle">{{ recent_topics.LAST_POST_SUBJECT }}</a>
+						</a> {% endif %}<a href="{{ recent_topics.U_VIEW_TOPIC }}" class="topictitle">{{ recent_topics.TOPIC_TITLE }}</a>
 
 						{% if recent_topics.ATTACH_ICON_IMG %}<i class="icon fa-paperclip fa-fw" aria-hidden="true"></i>{% endif %}
 

--- a/styles/we_clearblue/template/recent_topics_body_topbottom.html
+++ b/styles/we_clearblue/template/recent_topics_body_topbottom.html
@@ -46,7 +46,7 @@
 						{% if recent_topics.S_UNREAD_TOPIC and not S_IS_BOT %}
 						<a href="{{ recent_topics.U_NEWEST_POST }}">
 						<i class="icon fa-file fa-fw icon-red icon-md" aria-hidden="true"></i><span class="sr-only"></span>
-						</a> {% endif %}<a href="{{ recent_topics.U_LAST_POST }}" class="topictitle">{{ recent_topics.LAST_POST_SUBJECT }}</a>
+						</a> {% endif %}<a href="{{ recent_topics.U_VIEW_TOPIC }}" class="topictitle">{{ recent_topics.TOPIC_TITLE }}</a>
 
 						{% if recent_topics.ATTACH_ICON_IMG %}<i class="icon fa-paperclip fa-fw" aria-hidden="true"></i>{% endif %}
 


### PR DESCRIPTION
Retain expected behavior when clicking on a topic title.