### PR TITLE
Fix last-post screen reader label

### DIFF
--- a/styles/all/template/recent_topics_body_topbottom.html
+++ b/styles/all/template/recent_topics_body_topbottom.html
@@ -101,7 +101,7 @@
 						{% if not S_IS_BOT %}
 							<a href="{{ recent_topics.U_LAST_POST }}" title="{{ lang('GOTO_LAST_POST')|e('html_attr') }}">
 								<i class="icon fa-external-link-square fa-fw icon-lightgray icon-md" aria-hidden="true"></i>
-								<span class="sr-only">{{ VIEW_LATEST_POST }}</span>
+								<span class="sr-only">{{ lang('GOTO_LAST_POST') }}</span>
 							</a> {% endif %}<br />{{ recent_topics.LAST_POST_TIME }}
 						</span>
 					</dd>


### PR DESCRIPTION
Use the correct localized label for the last-post link in the recent topics template.

The issue was noticed when browsing the forum with the text-based Links browser. While the last-post icon is visible and clickable in graphical browsers, Links does not render the icon itself and relies on the link's textual content. The existing `VIEW_LATEST_POST` variable is undefined in this template, which leaves the `sr-only` label empty and makes the link effectively invisible in Links and potentially inaccessible to assistive technologies.

Use `lang('GOTO_LAST_POST')` instead, matching the link's existing `title` attribute and ensuring that it has a meaningful accessible name such as "Go to last post".
